### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/RaresHorjuOrg/f7fa67e4-d593-40de-83ed-6799ceca9cea/82ed7348-f954-4c4a-8eda-469338bf118e/_apis/work/boardbadge/6c593d03-df84-4a5e-945c-1b8a39a649ce)](https://dev.azure.com/RaresHorjuOrg/f7fa67e4-d593-40de-83ed-6799ceca9cea/_boards/board/t/82ed7348-f954-4c4a-8eda-469338bf118e/Microsoft.RequirementCategory)
 # PartsUnlimited
 Learning and Portofolio Project


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#159](https://dev.azure.com/RaresHorjuOrg/f7fa67e4-d593-40de-83ed-6799ceca9cea/_workitems/edit/159). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.